### PR TITLE
Update pytorch-lightning, pytorch, and docker compose

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM pytorch/pytorch:1.10.0-cuda11.3-cudnn8-devel
+FROM pytorch/pytorch:2.0.1-cuda11.7-cudnn8-devel
 
 ENV PROJECT=/mos4d
 RUN mkdir -p $PROJECT
@@ -21,7 +21,7 @@ RUN rm -rf $PROJECT
 
 RUN pip install -U git+https://github.com/NVIDIA/MinkowskiEngine -v --no-deps \
                            --install-option="--force_cuda" \
-                           --install-option="--cuda_home=/usr/local/cuda-11.3" \
+                           --install-option="--cuda_home=/usr/local/cuda-11.7" \
                            --install-option="--blas=openblas"
 
 

--- a/Makefile
+++ b/Makefile
@@ -3,22 +3,22 @@ export GROUP_ID:=$(shell id -g)
 
 build:
 	@echo Build docker image...
-	@docker-compose build project
+	@docker compose build project
 
 test: check-env
 	@echo NVIDIA and CUDA setup
-	@docker-compose run project nvidia-smi
+	@docker compose run project nvidia-smi
 	@echo Pytorch CUDA setup installed?
-	@docker-compose run project python3 -c "import torch; print(torch.cuda.is_available())"
+	@docker compose run project python3 -c "import torch; print(torch.cuda.is_available())"
 	@echo MinkowskiEngine installed?
-	@docker-compose run project python3 -c "import MinkowskiEngine as ME; print(ME.__version__)"
+	@docker compose run project python3 -c "import MinkowskiEngine as ME; print(ME.__version__)"
 
 run: check-env
-	@docker-compose run project
+	@docker compose run project
 
 clean:
 	@echo Removing docker image...
-	@docker-compose rm project
+	@docker compose rm project
 
 
 check-env:

--- a/Makefile
+++ b/Makefile
@@ -3,22 +3,22 @@ export GROUP_ID:=$(shell id -g)
 
 build:
 	@echo Build docker image...
-	@docker-compose build project
+	@DOCKER_BUILDKIT=0 docker compose build project
 
 test: check-env
 	@echo NVIDIA and CUDA setup
-	@docker-compose run project nvidia-smi
+	@docker compose run project nvidia-smi
 	@echo Pytorch CUDA setup installed?
-	@docker-compose run project python3 -c "import torch; print(torch.cuda.is_available())"
+	@docker compose run project python3 -c "import torch; print(torch.cuda.is_available())"
 	@echo MinkowskiEngine installed?
-	@docker-compose run project python3 -c "import MinkowskiEngine as ME; print(ME.__version__)"
+	@docker compose run project python3 -c "import MinkowskiEngine as ME; print(ME.__version__)"
 
 run: check-env
-	@docker-compose run project
+	@docker compose run project
 
 clean:
 	@echo Removing docker image...
-	@docker-compose rm project
+	@docker compose rm project
 
 
 check-env:

--- a/Makefile
+++ b/Makefile
@@ -3,22 +3,22 @@ export GROUP_ID:=$(shell id -g)
 
 build:
 	@echo Build docker image...
-	@docker compose build project
+	@docker-compose build project
 
 test: check-env
 	@echo NVIDIA and CUDA setup
-	@docker compose run project nvidia-smi
+	@docker-compose run project nvidia-smi
 	@echo Pytorch CUDA setup installed?
-	@docker compose run project python3 -c "import torch; print(torch.cuda.is_available())"
+	@docker-compose run project python3 -c "import torch; print(torch.cuda.is_available())"
 	@echo MinkowskiEngine installed?
-	@docker compose run project python3 -c "import MinkowskiEngine as ME; print(ME.__version__)"
+	@docker-compose run project python3 -c "import MinkowskiEngine as ME; print(ME.__version__)"
 
 run: check-env
-	@docker compose run project
+	@docker-compose run project
 
 clean:
 	@echo Removing docker image...
-	@docker compose rm project
+	@docker-compose rm project
 
 
 check-env:

--- a/scripts/predict_confidences.py
+++ b/scripts/predict_confidences.py
@@ -77,7 +77,7 @@ def main(weights, sequence, dt, poses, transform):
     model.freeze()
 
     # Setup trainer
-    trainer = Trainer(gpus=1, logger=False)
+    trainer = Trainer(accelerator="gpu", devices=1, logger=False)
 
     # Infer!
     trainer.predict(model, data.test_dataloader())

--- a/scripts/train.py
+++ b/scripts/train.py
@@ -72,7 +72,8 @@ def main(config, weights, checkpoint):
 
     # Setup trainer
     trainer = Trainer(
-        gpus=1,
+        accelerator="gpu",
+        devices=1,
         logger=tb_logger,
         max_epochs=cfg["TRAIN"]["MAX_EPOCH"],
         accumulate_grad_batches=cfg["TRAIN"]["ACC_BATCHES"],

--- a/scripts/train.py
+++ b/scripts/train.py
@@ -39,7 +39,6 @@ import mos4d.models.models as models
     default=None,
 )
 def main(config, weights, checkpoint):
-
     if checkpoint:
         cfg = torch.load(checkpoint)["hyper_parameters"]
     else:

--- a/setup.py
+++ b/setup.py
@@ -15,6 +15,5 @@ setup(
         "tqdm>=4.62.3",
         "torch",
         "ninja",
-        "requests<2.11.1", # Needed as long as docker-compose is used
     ],
 )

--- a/setup.py
+++ b/setup.py
@@ -8,12 +8,11 @@ setup(
     description="Receding Moving Object Segmentation in 3D LiDAR Data Using Sparse 4D Convolutions",
     packages=find_packages(where="src"),
     install_requires=[
-        "Click>=7.0",
-        "numpy>=1.20.3",
-        "pytorch_lightning>=1.6.4",
-        "PyYAML>=6.0",
-        "tqdm>=4.62.3",
-        "torch",
-        "ninja",
+        "Click",
+        "numpy",
+        "pytorch_lightning",
+        "tensorboard",
+        "PyYAML",
+        "tqdm",
     ],
 )

--- a/setup.py
+++ b/setup.py
@@ -15,5 +15,6 @@ setup(
         "tqdm>=4.62.3",
         "torch",
         "ninja",
+        "requests<2.11.1", # Needed as long as docker-compose is used
     ],
 )

--- a/src/mos4d/datasets/datasets.py
+++ b/src/mos4d/datasets/datasets.py
@@ -212,7 +212,6 @@ class KittiSequentialDataset(Dataset):
         past_files = self.filenames[seq][from_idx : to_idx : self.skip]
         list_past_point_clouds = [self.read_point_cloud(f) for f in past_files]
         for i, pcd in enumerate(list_past_point_clouds):
-
             # Transform to current viewpoint
             if self.transform:
                 from_pose = self.poses[seq][past_indices[i]]

--- a/src/mos4d/models/MinkowskiEngine/resnet.py
+++ b/src/mos4d/models/MinkowskiEngine/resnet.py
@@ -55,7 +55,6 @@ class ResNetBase(nn.Module):
         self.weight_initialization()
 
     def network_initialization(self, in_channels, out_channels, D):
-
         self.inplanes = self.INIT_DIM
         self.conv1 = nn.Sequential(
             ME.MinkowskiConvolution(

--- a/src/mos4d/models/metrics.py
+++ b/src/mos4d/models/metrics.py
@@ -15,7 +15,6 @@ class ClassificationMetrics(nn.Module):
         self.ignore_index = ignore_index
 
     def compute_confusion_matrix(self, pred_logits: torch.Tensor, gt_labels: torch.Tensor):
-
         # Set ignored classes to -inf to not influence softmax
         pred_logits[:, self.ignore_index] = -float("inf")
 

--- a/src/mos4d/models/models.py
+++ b/src/mos4d/models/models.py
@@ -167,8 +167,8 @@ class MOSNet(LightningModule):
         t = round(-step * self.dt_prediction, 3)
         mask = out.coordinates[:, -1].isclose(torch.tensor(t))
         pred_logits = out.features[mask].detach().cpu()
-        gt_labels = torch.cat(past_labels, dim=0).detach().cpu()
-        gt_labels = gt_labels[mask][:, 0]
+        gt_labels = torch.cat(past_labels, dim=0)
+        gt_labels = gt_labels[mask][:, 0].detach().cpu()
         confusion_matrix = self.ClassificationMetrics.compute_confusion_matrix(
             pred_logits, gt_labels
         )


### PR DESCRIPTION
This PR 
- adds some more changes to use 4DMOS with the latest pytorch
- moves to the newer docker-compose
- uses a newer pytorch docker image with cuda 11.7 support
- removes some dependency constraints 