### PR TITLE
Use the same parameter

### DIFF
--- a/src/mos4d/config/config.py
+++ b/src/mos4d/config/config.py
@@ -42,7 +42,6 @@ class MOSConfig(BaseModel):
     voxel_size_mos: float = 0.1
     delay_mos: int = 10
     prior: float = 0.25
-    n_scans: int = 10
     max_range_mos: float = 50.0
     min_range_mos: float = 0.0
 

--- a/src/mos4d/pipeline.py
+++ b/src/mos4d/pipeline.py
@@ -80,7 +80,7 @@ class MOS4DPipeline(OdometryPipeline):
         self.model.cuda().eval().freeze()
 
         self.odometry = Odometry(self.config.data, self.config.odometry)
-        self.buffer = deque(maxlen=self.config.mos.n_scans)
+        self.buffer = deque(maxlen=self.config.mos.delay_mos)
         self.dict_logits = {}
         self.dict_gt_labels = {}
 


### PR DESCRIPTION
The number of scans in the sequence and therefore the size of the buffer should be `delay_mos` everywhere.