### PR TITLE
Move deskewing

### DIFF
--- a/src/mos4d/odometry.py
+++ b/src/mos4d/odometry.py
@@ -70,8 +70,6 @@ class Odometry(KissICP):
             kernel=sigma / 3,
         )
 
-        point_deskewed = self.deskew(points, timestamps, self.last_delta)
-
         # Compute the difference between the prediction and the actual estimate
         model_deviation = np.linalg.inv(initial_guess) @ new_pose
 
@@ -81,7 +79,9 @@ class Odometry(KissICP):
         self.last_delta = np.linalg.inv(self.last_pose) @ new_pose
         self.last_pose = new_pose
 
-        return self.transform(point_deskewed, self.last_pose)
+        points_deskewed = self.deskew(points, timestamps, self.last_delta)
+
+        return self.transform(points_deskewed, self.last_pose)
 
     def transform(self, points, pose):
         points_hom = np.hstack((points, np.ones((len(points), 1))))


### PR DESCRIPTION
Since we de-skew the non-preprocessed scan for MOS anyway, we should do it after registration to use the latest motion estimate.