### PR TITLE
Revert "Move deskewing"

### DIFF
--- a/src/mos4d/odometry.py
+++ b/src/mos4d/odometry.py
@@ -70,6 +70,8 @@ class Odometry(KissICP):
             kernel=sigma / 3,
         )
 
+        point_deskewed = self.deskew(points, timestamps, self.last_delta)
+
         # Compute the difference between the prediction and the actual estimate
         model_deviation = np.linalg.inv(initial_guess) @ new_pose
 
@@ -79,9 +81,7 @@ class Odometry(KissICP):
         self.last_delta = np.linalg.inv(self.last_pose) @ new_pose
         self.last_pose = new_pose
 
-        points_deskewed = self.deskew(points, timestamps, self.last_delta)
-
-        return self.transform(points_deskewed, self.last_pose)
+        return self.transform(point_deskewed, self.last_pose)
 
     def transform(self, points, pose):
         points_hom = np.hstack((points, np.ones((len(points), 1))))


### PR DESCRIPTION
Reverts PRBonn/4DMOS#49

I reran some experiments, and this did not lead to better results. Since the estimated pose reduces the point-to-points error of the scan deskewed with the constant velocity model and the map, we should keep using that scan (or run a second registration step).